### PR TITLE
Remove stable as the base theme now it no longer exists

### DIFF
--- a/gla_core_theme.info.yml
+++ b/gla_core_theme.info.yml
@@ -3,7 +3,7 @@ type: theme
 description: Core theme for Drupal sites in the GLA digital estate
 core: 8.x
 core_version_requirement: ^8 || ^9
-base theme: stable
+base theme: false
 
 libraries:
   - 'gla_core_theme/global'


### PR DESCRIPTION
Instead, we use no base theme at all.

This fixes these messages:

```
Unable to uninstall the <em class="placeholder">Stable</em> theme since the <em class="placeholder">GLA core theme</em> theme is installed
```