### PR TITLE
DERP-253 - Restrict Globby to v11 so we don't need to move everything…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9440,28 +9440,16 @@
       }
     },
     "globby": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-12.0.0.tgz",
-      "integrity": "sha512-3mOIUduqSMHm6gNjIw9E641TZ93NB8lFVt+6MKIw6vUaIS5aSsw/6cl0gT86z1IoKlaL90BiOQlA593GUMlzEA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+      "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
       "requires": {
-        "array-union": "^3.0.1",
+        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.7",
-        "ignore": "^5.1.8",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "dependencies": {
-        "array-union": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-          "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="
-        },
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
-        }
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
       }
     },
     "globjoin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",
-    "globby": "^12.0.0",
+    "globby": "^11.0.0",
     "jsonfile": "^6.1.0",
     "lodash": "^4.17.21",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
… to ESM

Globby 12 switched to being pure ESM: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

The theme isn't set up as an ES module and we don't have time to do that before the sprint demo, so for now the easiest thing to do is just stick with v11 which will work with the CommonJS `require` approach.